### PR TITLE
Fix route53 updater

### DIFF
--- a/config/pmd/potential-future-pmd.xml
+++ b/config/pmd/potential-future-pmd.xml
@@ -66,6 +66,7 @@
   <rule ref="category/java/performance.xml">
     <exclude name="ConsecutiveLiteralAppends"/>
     <exclude name="AvoidInstantiatingObjectsInLoops"/>
+    <exclude name="UseStringBufferForStringAppends"/>
   </rule>
 
   <rule ref="category/java/design.xml/TooManyMethods">

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies{
-    compile 'no.bibsys.aws:aws-build-tools:2018.11.30.14.29'
+    compile 'no.bibsys.aws:aws-build-tools:2018.12.01.20.46'
 
 }
 

--- a/service/src/main/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdater.java
+++ b/service/src/main/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdater.java
@@ -18,17 +18,24 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Updates the OpenApi specification stored in SwaggerHub for a specific ApiGateway API.
+ *
+ * If the branch is master then the API name in SwaggerHub is the one specified in the constructor.
+ * If the branch is not the master then the API name in SwaggerHub is the name of the Stack.
+ *
  */
 
 public class SwaggerHubUpdater {
 
 
     private static final Logger logger = LoggerFactory.getLogger(SwaggerHubUpdater.class);
+
+
     private final transient SwaggerHubInfo swaggerHubInfo;
     private final transient AmazonApiGateway apiGateway;
     private final transient String swaggerApiKey;
     private final transient String apiGatewayRestApiId;
     protected transient Stage stage;
+
 
     public SwaggerHubUpdater(
         AmazonApiGateway apiGateway,
@@ -61,8 +68,7 @@ public class SwaggerHubUpdater {
     public int deleteApiVersion() throws URISyntaxException, IOException {
         SwaggerDriver swaggerDriver=new SwaggerDriver(swaggerHubInfo);
         HttpDelete deleteRequest = swaggerDriver.createDeleteVersionRequest(swaggerApiKey);
-        int result=swaggerDriver.executeDelete(deleteRequest);
-        return result;
+        return swaggerDriver.executeDelete(deleteRequest);
     }
 
 
@@ -128,6 +134,11 @@ public class SwaggerHubUpdater {
         ApiGatewayApiInfo apiGatewayApiInfo = new ApiGatewayApiInfo(stage, apiGateway, apiGatewayRestApiId);
         return apiGatewayApiInfo.generateOpenApiNoExtensions();
 
+    }
+
+
+    public SwaggerHubInfo getSwaggerHubInfo() {
+        return swaggerHubInfo;
     }
 
 

--- a/service/src/main/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdater.java
+++ b/service/src/main/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdater.java
@@ -32,7 +32,7 @@ public class SwaggerHubUpdater {
 
     private final transient SwaggerHubInfo swaggerHubInfo;
     private final transient AmazonApiGateway apiGateway;
-    private final transient String swaggerApiKey;
+
     private final transient String apiGatewayRestApiId;
     protected transient Stage stage;
 
@@ -48,7 +48,7 @@ public class SwaggerHubUpdater {
         this.apiGatewayRestApiId = apiGatewayRestApiId;
         this.stage = stage;
         this.swaggerHubInfo = intializeSwaggerHubInfo(swaggerHubInfo,gitInfo,stackName);
-        this.swaggerApiKey = swaggerHubInfo.getSwaggerAuth();
+
     }
 
     private SwaggerHubInfo intializeSwaggerHubInfo(SwaggerHubInfo swaggerHubInfo, GitInfo gitInfo,String stackName) {
@@ -66,6 +66,7 @@ public class SwaggerHubUpdater {
 
 
     public int deleteApiVersion() throws URISyntaxException, IOException {
+        String swaggerApiKey = swaggerHubInfo.getSwaggerAuth();
         SwaggerDriver swaggerDriver=new SwaggerDriver(swaggerHubInfo);
         HttpDelete deleteRequest = swaggerDriver.createDeleteVersionRequest(swaggerApiKey);
         return swaggerDriver.executeDelete(deleteRequest);
@@ -80,6 +81,7 @@ public class SwaggerHubUpdater {
      * @return Success of Failure code the delete request
      */
     public int deleteApi() throws URISyntaxException, IOException {
+        String swaggerApiKey = swaggerHubInfo.getSwaggerAuth();
         SwaggerDriver swaggerDriver = new SwaggerDriver(swaggerHubInfo);
         HttpDelete deleteRequest = swaggerDriver.createDeleteApiRequest(swaggerApiKey);
         return swaggerDriver.executeDelete(deleteRequest);
@@ -113,7 +115,7 @@ public class SwaggerHubUpdater {
 
 
     private String readTheUpdatedAPI(SwaggerDriver swaggerDriver) throws URISyntaxException, IOException {
-
+        String swaggerApiKey = swaggerHubInfo.getSwaggerAuth();
         HttpGet getSpecRequest = swaggerDriver.getSpecificationRequest(swaggerApiKey);
         return swaggerDriver.executeGet(getSpecRequest);
     }
@@ -124,6 +126,7 @@ public class SwaggerHubUpdater {
     }
 
     private void executeUpdate(String json, SwaggerDriver swaggerDriver) throws URISyntaxException, IOException {
+        String swaggerApiKey = swaggerHubInfo.getSwaggerAuth();
         HttpPost request = swaggerDriver.createUpdateRequest(json, swaggerApiKey);
         swaggerDriver.executePost(request);
 

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceDestroyer.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceDestroyer.java
@@ -22,8 +22,7 @@ import org.slf4j.LoggerFactory;
  * stack (either inside or outside AWS). It also deletes the disconnected resources. It is usually
  * called thought a handler of a Lambda function (see {@link no.bibsys.aws.lambda.deploy.handlers.DestroyHandler}).
  * <p>Currently it deletes the API from SwaggerHub and all Route53 and ApiGateway configurations
- * related to attaching the
- * branch's RestApi to a static url.
+ * related to attaching the branch's RestApi to a static url.
  * </p>
  */
 
@@ -49,7 +48,8 @@ public class ResourceDestroyer extends ResourceManager {
         swaggerHubUpdater = initSwaggerHubUpdater(stackName, swaggerHubInfo, stage, gitInfo,
             apiGateway, apiGatewayRestApi);
 
-        route53Updater = new Route53Updater(staticUrlInfo, apiGatewayRestApi, apiGateway);
+        StaticUrlInfo newStaticUrlInfo = initStaticUrlInfo(staticUrlInfo, gitInfo.getBranch());
+        route53Updater = new Route53Updater(newStaticUrlInfo, apiGatewayRestApi, apiGateway);
     }
 
 

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceInitializer.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceInitializer.java
@@ -23,8 +23,7 @@ import org.slf4j.LoggerFactory;
  * not belong to the Stack. These resources can be inside or outside AWS. <br/> It is usually called
  * thought a handler of a Lambda function (see {@link no.bibsys.aws.lambda.deploy.handlers.InitHandler}).
  * <p>Currently it stores the API specification to SwaggerHub and creates all Route53 and
- * ApiGateway
- * <br/>configurations related to attaching the branch's RestApi to a static url.
+ * ApiGateway <br/>configurations related to attaching the branch's RestApi to a static url.
  * </p>
  */
 public class ResourceInitializer extends ResourceManager {
@@ -42,7 +41,7 @@ public class ResourceInitializer extends ResourceManager {
         SwaggerHubInfo swaggerHubInfo,
         Stage stage,
         GitInfo gitInfo
-        ) throws IOException {
+    ) throws IOException {
         super();
         AmazonApiGateway apiGateway = AmazonApiGatewayClientBuilder.defaultClient();
         String apiGatewayRestApi = findRestApi(stackName);
@@ -50,7 +49,8 @@ public class ResourceInitializer extends ResourceManager {
         this.swaggerHubUpdater = initSwaggerHubUpdater(stackName, swaggerHubInfo, stage, gitInfo,
             apiGateway, apiGatewayRestApi);
 
-        this.route53Updater = new Route53Updater(staticUrlInfo, apiGatewayRestApi, apiGateway);
+        StaticUrlInfo newStaticUrlInfo = initStaticUrlInfo(staticUrlInfo, gitInfo.getBranch());
+        route53Updater = new Route53Updater(newStaticUrlInfo, apiGatewayRestApi, apiGateway);
         this.certificateArn = certificateArn;
     }
 

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
@@ -47,7 +47,7 @@ public class ResourceManager {
 
             String randomString = DigestUtils.sha1Hex(gitBranch).substring(0, 5);
             String newUrl = String.format("%s.%s", randomString, staticUrlInfo.getRecordSetName());
-            return new StaticUrlInfo(staticUrlInfo.getDomainName(), newUrl,
+            return new StaticUrlInfo(staticUrlInfo.getZoneName(), newUrl,
                 staticUrlInfo.getStage());
         }
 

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
@@ -47,6 +47,9 @@ public class ResourceManager {
 
             String randomString = DigestUtils.sha1Hex(gitBranch).substring(0, 5);
             String newUrl = String.format("%s.%s", randomString, staticUrlInfo.getRecordSetName());
+            if (staticUrlInfo.getStage().equals(Stage.TEST)) {
+                newUrl = "test." + newUrl;
+            }
             return new StaticUrlInfo(staticUrlInfo.getZoneName(), newUrl,
                 staticUrlInfo.getStage());
         }

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
@@ -41,18 +41,21 @@ public class ResourceManager {
 
     protected StaticUrlInfo initStaticUrlInfo(StaticUrlInfo staticUrlInfo, String gitBranch) {
 
-        if (gitBranch.equals(GitConstants.MASTER)) {
-            return staticUrlInfo;
-        } else {
+        StaticUrlInfo newStaticUrlInfo = staticUrlInfo;
+        if (!gitBranch.equals(GitConstants.MASTER)) {
 
             String randomString = DigestUtils.sha1Hex(gitBranch).substring(0, 5);
             String newUrl = String.format("%s.%s", randomString, staticUrlInfo.getRecordSetName());
-            if (staticUrlInfo.getStage().equals(Stage.TEST)) {
-                newUrl = "test." + newUrl;
-            }
-            return new StaticUrlInfo(staticUrlInfo.getZoneName(), newUrl,
+            newStaticUrlInfo=new StaticUrlInfo(staticUrlInfo.getZoneName(), newUrl,
                 staticUrlInfo.getStage());
         }
+        if (staticUrlInfo.getStage().equals(Stage.TEST)) {
+            String newUrl="test."+staticUrlInfo.getRecordSetName();
+            newStaticUrlInfo=new StaticUrlInfo(newStaticUrlInfo.getZoneName(),
+                newUrl,
+                newStaticUrlInfo.getStage());
+        }
+        return newStaticUrlInfo;
 
 
     }

--- a/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
+++ b/service/src/main/java/no/bibsys/aws/utils/resources/ResourceManager.java
@@ -9,7 +9,10 @@ import no.bibsys.aws.cloudformation.helpers.ResourceType;
 import no.bibsys.aws.cloudformation.helpers.StackResources;
 import no.bibsys.aws.git.github.GitInfo;
 import no.bibsys.aws.lambda.deploy.handlers.SwaggerHubUpdater;
+import no.bibsys.aws.route53.StaticUrlInfo;
 import no.bibsys.aws.swaggerhub.SwaggerHubInfo;
+import no.bibsys.aws.utils.constants.GitConstants;
+import org.apache.commons.codec.digest.DigestUtils;
 
 public class ResourceManager {
 
@@ -17,8 +20,9 @@ public class ResourceManager {
     protected String findRestApi(String stackId) {
         StackResources stackResources = new StackResources(stackId);
         Optional<String> restApiId = stackResources.getResources(ResourceType.REST_API).stream()
-                .map(resource -> resource.getPhysicalResourceId()).findAny();
-        return restApiId.orElseThrow(() -> new NotFoundException("Could not find an API Gateway Rest API"));
+            .map(resource -> resource.getPhysicalResourceId()).findAny();
+        return restApiId
+            .orElseThrow(() -> new NotFoundException("Could not find an API Gateway Rest API"));
 
     }
 
@@ -32,5 +36,21 @@ public class ResourceManager {
             stage,
             stackName,
             gitInfo);
+    }
+
+
+    protected StaticUrlInfo initStaticUrlInfo(StaticUrlInfo staticUrlInfo, String gitBranch) {
+
+        if (gitBranch.equals(GitConstants.MASTER)) {
+            return staticUrlInfo;
+        } else {
+
+            String randomString = DigestUtils.sha1Hex(gitBranch).substring(0, 5);
+            String newUrl = String.format("%s.%s", randomString, staticUrlInfo.getRecordSetName());
+            return new StaticUrlInfo(staticUrlInfo.getDomainName(), newUrl,
+                staticUrlInfo.getStage());
+        }
+
+
     }
 }

--- a/service/src/main/resources/openapi/openapi.yml
+++ b/service/src/main/resources/openapi/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.0
+openapi: 3.0.1
 info:
-  title: aut-reg-inf-autreg-58-openapi-lambdab-final
-  version: "1.0-oas3"
+  title: API for bulding pipelines
+  version: "1.0"
 servers:
 - url: '<SERVER_PLACEHOLDER>'
   variables:

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -253,9 +253,6 @@ Resources:
     Description: CodeBuild project for using in the CodePipeline
     Properties:
       Name: !Ref CodebuildProjectname
-      Artifacts:
-        Name: !Ref CodebuildOutputArtifact
-        Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
       Environment:

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -253,7 +253,8 @@ Resources:
     Description: CodeBuild project for using in the CodePipeline
     Properties:
       Name: !Ref CodebuildProjectname
-      Artifacts: {}
+      Artifacts:
+        Type: NO_ARTIFACTS
       Source:
         Type: CODEPIPELINE
       Environment:

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -279,7 +279,7 @@ Resources:
     Properties:
       Name: !Ref ExecuteTestsProjectname
       Artifacts:
-        Type: NO_ARTIFACT
+        Type:  NO_ARTIFACTS
       Source:
         Type: CODEPIPELINE
         BuildSpec: "testspec.yml"

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -279,6 +279,7 @@ Resources:
     Properties:
       Name: !Ref ExecuteTestsProjectname
       Artifacts:
+        # when using CodePipeline both sourceType, and artifactType must be set to: CODEPIPELINE
         Type:  CODEPIPELINE
       Source:
         Type: CODEPIPELINE

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -256,7 +256,7 @@ Resources:
       Artifacts:
         Type: NO_ARTIFACTS
       Source:
-        Type: CODEPIPELINE
+        Type:  S3
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: "aws/codebuild/eb-java-8-amazonlinux-64:2.4.3"

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -279,7 +279,7 @@ Resources:
     Properties:
       Name: !Ref ExecuteTestsProjectname
       Artifacts:
-        Type:  NO_ARTIFACTS
+        Type:  CODEPIPELINE
       Source:
         Type: CODEPIPELINE
         BuildSpec: "testspec.yml"

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -253,6 +253,7 @@ Resources:
     Description: CodeBuild project for using in the CodePipeline
     Properties:
       Name: !Ref CodebuildProjectname
+      Artifacts: {}
       Source:
         Type: CODEPIPELINE
       Environment:

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -256,7 +256,7 @@ Resources:
       Artifacts:
         Type: NO_ARTIFACTS
       Source:
-        Type:  S3
+        Type: NO_ARTIFACTS
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: "aws/codebuild/eb-java-8-amazonlinux-64:2.4.3"

--- a/service/src/main/resources/templates/pipelineTemplate.yaml
+++ b/service/src/main/resources/templates/pipelineTemplate.yaml
@@ -254,9 +254,10 @@ Resources:
     Properties:
       Name: !Ref CodebuildProjectname
       Artifacts:
-        Type: NO_ARTIFACTS
+        Name: !Ref CodebuildOutputArtifact
+        Type: CODEPIPELINE
       Source:
-        Type: NO_ARTIFACTS
+        Type: CODEPIPELINE
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: "aws/codebuild/eb-java-8-amazonlinux-64:2.4.3"
@@ -278,8 +279,7 @@ Resources:
     Properties:
       Name: !Ref ExecuteTestsProjectname
       Artifacts:
-        Name: !Ref CodebuildOutputArtifact
-        Type: CODEPIPELINE
+        Type: NO_ARTIFACT
       Source:
         Type: CODEPIPELINE
         BuildSpec: "testspec.yml"

--- a/service/src/test/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdaterTest.java
+++ b/service/src/test/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdaterTest.java
@@ -1,0 +1,58 @@
+package no.bibsys.aws.lambda.deploy.handlers;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import no.bibsys.aws.cloudformation.Stage;
+import no.bibsys.aws.git.github.BranchInfo;
+import no.bibsys.aws.swaggerhub.SwaggerHubInfo;
+import org.junit.Test;
+
+public class SwaggerHubUpdaterTest {
+
+    private static final String API_ID = "apiId";
+    private static final String API_VERSION = "apiVersion";
+    private static final String SWAGGER_ORG = "swaggerOrg";
+    private static final String STACK_NAME = "stackName";
+
+
+    @Test
+    public void swaggerHubUpdater_notMasterBranch_restAPIWithStackName() throws IOException {
+        SwaggerHubInfo swaggerHubInfo = new SwaggerHubInfo(API_ID, API_VERSION, SWAGGER_ORG);
+        BranchInfo branchInfo = new BranchInfo(null, "notmaster");
+        SwaggerHubUpdater swaggerHubUpdater = new SwaggerHubUpdater(
+            null,
+            null,
+            swaggerHubInfo,
+            Stage.FINAL,
+            STACK_NAME,
+            branchInfo);
+
+        SwaggerHubInfo newInfo = swaggerHubUpdater.getSwaggerHubInfo();
+        assertThat(newInfo.getApiId(), is(equalTo(STACK_NAME)));
+
+
+    }
+
+
+    @Test
+    public void swaggerHubUpdater_masterBranch_restAPIWithStackName() throws IOException {
+        SwaggerHubInfo swaggerHubInfo = new SwaggerHubInfo(API_ID, API_VERSION, SWAGGER_ORG);
+        BranchInfo branchInfo = new BranchInfo(null, "master");
+        SwaggerHubUpdater swaggerHubUpdater = new SwaggerHubUpdater(
+            null,
+            null,
+            swaggerHubInfo,
+            Stage.FINAL,
+            STACK_NAME,
+            branchInfo);
+
+        SwaggerHubInfo newInfo = swaggerHubUpdater.getSwaggerHubInfo();
+        assertThat(newInfo.getApiId(), is(equalTo(API_ID)));
+
+
+    }
+
+}

--- a/service/src/test/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdaterTest.java
+++ b/service/src/test/java/no/bibsys/aws/lambda/deploy/handlers/SwaggerHubUpdaterTest.java
@@ -38,7 +38,7 @@ public class SwaggerHubUpdaterTest {
 
 
     @Test
-    public void swaggerHubUpdater_masterBranch_restAPIWithStackName() throws IOException {
+    public void swaggerHubUpdater_masterBranch_restAPIWithPredeternminedApiId() throws IOException {
         SwaggerHubInfo swaggerHubInfo = new SwaggerHubInfo(API_ID, API_VERSION, SWAGGER_ORG);
         BranchInfo branchInfo = new BranchInfo(null, "master");
         SwaggerHubUpdater swaggerHubUpdater = new SwaggerHubUpdater(

--- a/service/src/test/java/no/bibsys/utils/ResourceManagerTests.java
+++ b/service/src/test/java/no/bibsys/utils/ResourceManagerTests.java
@@ -32,7 +32,7 @@ public class ResourceManagerTests extends ResourceManager {
 
 
     @Test
-    public void initRoute53Updater_gitBranch_alteredUrlIfBrancIsMaster() {
+    public void initRoute53Updater_gitBranch_originaldUrlIfBrancIsMaster() {
         String originalUrl = "originalUrl";
         StaticUrlInfo staticUrlInfo = new StaticUrlInfo("zoneName", originalUrl, Stage.FINAL);
 

--- a/service/src/test/java/no/bibsys/utils/ResourceManagerTests.java
+++ b/service/src/test/java/no/bibsys/utils/ResourceManagerTests.java
@@ -1,0 +1,49 @@
+package no.bibsys.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+
+import no.bibsys.aws.cloudformation.Stage;
+import no.bibsys.aws.route53.StaticUrlInfo;
+import no.bibsys.aws.utils.resources.ResourceManager;
+import org.junit.Test;
+
+public class ResourceManagerTests extends ResourceManager {
+
+
+    @Test
+    public void initRoute53Updater_gitBranch_alteredUrlIfBranchNotMaster() {
+        String originalUrl = "originalUrl";
+        StaticUrlInfo staticUrlInfo = new StaticUrlInfo("zoneName", originalUrl, Stage.FINAL);
+
+        StaticUrlInfo info = initStaticUrlInfo(staticUrlInfo, "notmaster");
+
+        String newUrl = info.getRecordSetName();
+
+        int prefixIndex = newUrl.indexOf(".");
+        assertThat(prefixIndex, is(greaterThan(0)));
+        assertThat(newUrl, is(not(equalTo(originalUrl))));
+
+    }
+
+
+    @Test
+    public void initRoute53Updater_gitBranch_alteredUrlIfBrancIsMaster() {
+        String originalUrl = "originalUrl";
+        StaticUrlInfo staticUrlInfo = new StaticUrlInfo("zoneName", originalUrl, Stage.FINAL);
+
+        StaticUrlInfo info = initStaticUrlInfo(staticUrlInfo, "master");
+
+        String newUrl = info.getRecordSetName();
+
+        int prefixIndex = newUrl.indexOf(".");
+        assertThat(prefixIndex, is(lessThan(0)));
+        assertThat(newUrl, is(equalTo(originalUrl)));
+
+    }
+
+}


### PR DESCRIPTION
Description: ResourceInitializer and ResourceDestroyer create the same URL for all branches
Modifies: ResourceInitializer, ResourceDestroyer
FIx: If the branch is not master add a hash string as prefix for the static urls